### PR TITLE
create the config directory if it does not exist

### DIFF
--- a/cmd/reflow/ec2.go
+++ b/cmd/reflow/ec2.go
@@ -156,6 +156,12 @@ The resulting configuration can be examined with "reflow config".`
 	if err != nil {
 		c.Fatal(err)
 	}
+
+	configPath := filepath.Dir(c.ConfigFile)
+	if err := os.MkdirAll(configPath, 0766); err != nil {
+		c.Fatal(err)
+	}
+
 	if err := ioutil.WriteFile(c.ConfigFile, b, 0666); err != nil {
 		c.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #3  by creating the directory for the config file.