### PR TITLE
fix go.mod and disable cache assertion test by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/grailbio/reflow
 go 1.12
 
 require (
+        docker.io/go-docker v1.0.0
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/DATA-DOG/go-sqlmock v1.3.3 // indirect
 	github.com/Microsoft/go-winio v0.4.5 // indirect
-	github.com/aws/aws-sdk-go v1.20.14
+	github.com/aws/aws-sdk-go v1.25.10
 	github.com/aws/aws-xray-sdk-go v1.0.0-rc.2
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/docker/distribution v2.7.0+incompatible
@@ -17,19 +18,19 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20190116191554-efb7e1b888e1
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
-	github.com/grailbio/base v0.0.0-20190703175603-85a816db02fd
-	github.com/grailbio/infra v0.0.0-20190703181726-1a3f7bfef78a
+	github.com/grailbio/base v0.0.6
+	github.com/grailbio/infra v0.0.0-20191113175114-718e1fd91fc6
 	github.com/grailbio/testutil v0.0.3
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/willf/bloom v2.0.3+incompatible
-	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
-	golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c
-	gopkg.in/yaml.v2 v2.2.2
+        golang.org/x/net v0.0.0-20191007182048-72f939374954
+        golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+        golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+        golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff
+        gopkg.in/yaml.v2 v2.2.4
 	gotest.tools v2.2.0+incompatible // indirect
-	v.io/x/lib v0.1.3
+	v.io/x/lib v0.1.4
 )

--- a/go.mod
+++ b/go.mod
@@ -26,11 +26,11 @@ require (
 	github.com/sirupsen/logrus v1.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/willf/bloom v2.0.3+incompatible
-        golang.org/x/net v0.0.0-20191007182048-72f939374954
-        golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-        golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-        golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff
-        gopkg.in/yaml.v2 v2.2.4
+	golang.org/x/net v0.0.0-20191007182048-72f939374954
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
+	golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff
+	gopkg.in/yaml.v2 v2.2.4
 	gotest.tools v2.2.0+incompatible // indirect
 	v.io/x/lib v0.1.4
 )

--- a/test/integration/cache_assertion_test.go
+++ b/test/integration/cache_assertion_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package cache_assertion_test
 
 import (


### PR DESCRIPTION
Cache assertion test requires a binary to be built. Disable it from running by default