### PR TITLE
reflow/flow: Return reserved resources in Flow.ExecConfig

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -761,7 +761,7 @@ func (f *Flow) ExecConfig() reflow.ExecConfig {
 			NeedAWSCreds:  strings.HasSuffix(f.OriginalImage, "$aws") || strings.HasSuffix(f.Image, "$aws"),
 			Cmd:           f.Cmd,
 			Args:          args,
-			Resources:     f.Resources,
+			Resources:     f.Reserved,
 			OutputIsDir:   f.OutputIsDir,
 		}
 	default:


### PR DESCRIPTION
Currently, Flow.ExecConfig returns f.Resources for an Exec's Execonfig. Since resources are reserved before running an exec and the flow's reserved resources can change if its corresponding task OOMs, changing ExecConfig to reflect this allows it to always return the most up-to-date resources for an Exec.