### PR TITLE
Skip watcher test on darwin

### DIFF
--- a/ec2cluster/volume/volume_test.go
+++ b/ec2cluster/volume/volume_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/grailbio/reflow/log"
 )
 
+var errTest = fmt.Errorf("test error")
+
 func descVolsFn(m map[string]int64, err error) func() (*ec2.DescribeVolumesOutput, error) {
 	var out *ec2.DescribeVolumesOutput
 	if err == nil {

--- a/ec2cluster/volume/watcher_test.go
+++ b/ec2cluster/volume/watcher_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// +build -darwin
+
 package volume
 
 import (
@@ -15,16 +17,14 @@ import (
 	"github.com/grailbio/reflow/log"
 )
 
-var (
-	errTest           = fmt.Errorf("test error")
-	testWatcherParams = infra.VolumeWatcher{
-		LowThresholdPct:       50.0,
-		HighThresholdPct:      75.0,
-		WatcherSleepDuration:  100 * time.Millisecond,
-		ResizeSleepDuration:   50 * time.Millisecond,
-		FastThresholdDuration: 50 * time.Millisecond,
-	}
-)
+var testWatcherParams = infra.VolumeWatcher{
+	LowThresholdPct:       50.0,
+	HighThresholdPct:      75.0,
+	WatcherSleepDuration:  100 * time.Millisecond,
+	ResizeSleepDuration:   50 * time.Millisecond,
+	FastThresholdDuration: 50 * time.Millisecond,
+}
+
 
 type testVolume struct {
 	size                          data.Size


### PR DESCRIPTION
These tests keep failing on darwin, so we'll skip them.
The underlying code being tested never runs on darwin anyway.
