### PR TITLE
Simplify return type of (Path).Match

### DIFF
--- a/syntax/coerce.go
+++ b/syntax/coerce.go
@@ -19,8 +19,8 @@ func coerceMatch(v values.T, t *types.T, pos scanner.Position, p Path) (values.T
 	if f, ok := v.(*flow.Flow); ok {
 		return coerceMatchFlow(f, t, pos, p), nil
 	}
-	v, t, ok, p, err := p.Match(v, t)
-	if !ok {
+	v, t, p, err := p.Match(v, t)
+	if err != nil {
 		return nil, errors.E(pos.String(), err)
 	}
 	return coerceMatch(v, t, pos, p)
@@ -34,12 +34,9 @@ func coerceMatchFlow(f *flow.Flow, t *types.T, pos scanner.Position, p Path) *fl
 		K: func(vs []values.T) *flow.Flow {
 			v, t, p := vs[0], t, p
 			for {
-				var (
-					err error
-					ok  bool
-				)
-				v, t, ok, p, err = p.Match(v, t)
-				if !ok {
+				var err error
+				v, t, p, err = p.Match(v, t)
+				if err != nil {
 					return &flow.Flow{
 						Op:  flow.Val,
 						Err: errors.Recover(errors.E(pos.String(), err)),

--- a/syntax/pat.go
+++ b/syntax/pat.go
@@ -553,9 +553,10 @@ func (m *Matcher) Path() Path {
 // Path represents a path to a value.
 type Path []*Matcher
 
-// Match performs single step deconstruction of a type and value.
-// It returns the next level; terminating when len(Path) == 0.
-func (p Path) Match(v values.T, t *types.T) (values.T, *types.T, bool, Path, error) {
+// Match performs single step deconstruction of a type and value. It returns the
+// next level; terminating when len(Path) == 0. If the path does not match,
+// return an error.
+func (p Path) Match(v values.T, t *types.T) (values.T, *types.T, Path, error) {
 	if len(p) == 0 {
 		panic("bad path")
 	}
@@ -564,41 +565,41 @@ func (p Path) Match(v values.T, t *types.T) (values.T, *types.T, bool, Path, err
 	default:
 		panic("bad path")
 	case MatchValue:
-		return v, t, true, p, nil
+		return v, t, p, nil
 	case MatchTuple:
-		return v.(values.Tuple)[m.Index], t.Fields[m.Index].T, true, p, nil
+		return v.(values.Tuple)[m.Index], t.Fields[m.Index].T, p, nil
 	case MatchList:
 		l := v.(values.List)
 		if len(l) < m.Length {
-			return nil, t.Elem, false, p, errors.Errorf("cannot match list pattern of size %d with a list of size %d", m.Length, len(l))
+			return nil, nil, nil, errors.Errorf("cannot match list pattern of size %d with a list of size %d", m.Length, len(l))
 		}
 		if !m.AllowTail && m.Length < len(l) {
-			return nil, t.Elem, false, p, errors.Errorf("cannot match list pattern of size %d with a list of size %d", m.Length, len(l))
+			return nil, nil, nil, errors.Errorf("cannot match list pattern of size %d with a list of size %d", m.Length, len(l))
 		}
 		if len(l) <= m.Index {
 			panic("matcher index exceeds list length; should be caught by length check")
 		}
-		return l[m.Index], t.Elem, true, p, nil
+		return l[m.Index], t.Elem, p, nil
 	case MatchListTail:
 		l := v.(values.List)
 		if len(l) < m.Length {
-			return nil, t.Elem, false, p, errors.Errorf("cannot match pattern of size %d with a list of size %d", m.Length, len(l))
+			return nil, nil, nil, errors.Errorf("cannot match pattern of size %d with a list of size %d", m.Length, len(l))
 		}
 		if !m.AllowTail {
 			panic("must allow tails to match tail")
 		}
-		return l[m.Length:], t, true, p, nil
+		return l[m.Length:], t, p, nil
 	case MatchStruct:
-		return v.(values.Struct)[m.Field], t.Field(m.Field), true, p, nil
+		return v.(values.Struct)[m.Field], t.Field(m.Field), p, nil
 	case MatchVariant:
 		variant := v.(*values.Variant)
 		if variant.Tag != m.Tag {
-			return nil, t, false, p, errors.Errorf("cannot match tag #%s with a variant with tag #%s", m.Tag, variant.Tag)
+			return nil, nil, nil, errors.Errorf("cannot match tag #%s with a variant with tag #%s", m.Tag, variant.Tag)
 		}
 		if variant.Elem == nil {
-			return v, t, true, p, nil
+			return v, t, p, nil
 		}
-		return variant.Elem, t.VariantMap()[variant.Tag], true, p, nil
+		return variant.Elem, t.VariantMap()[variant.Tag], p, nil
 	}
 }
 

--- a/syntax/pat_test.go
+++ b/syntax/pat_test.go
@@ -233,16 +233,12 @@ func TestMatchers(t *testing.T) {
 		var (
 			v   values.T = v
 			typ          = typ
-			ok  bool
-			p   = m.Path()
+			p            = m.Path()
 			err error
 		)
 		for !p.Done() {
-			v, typ, ok, p, err = p.Match(v, typ)
+			v, typ, p, err = p.Match(v, typ)
 			if err != nil {
-				if ok {
-					t.Errorf("got error, but ok == true")
-				}
 				t.Fatalf("unexpected match failure %s", err)
 			}
 		}

--- a/syntax/switch.go
+++ b/syntax/switch.go
@@ -159,12 +159,8 @@ func (s *evalSwitch) evalPath(
 			},
 		}, nil
 	}
-	// We throw away the error, because we know that the `Match` only uses its
-	// error to describe why the match failed, which we don't care about in
-	// this case.  There's some potential future world where `Match` can fail
-	// in ways we want to report.  We'll need to revisit this at that time.
-	nextV, nextT, ok, path, _ := p.path.Match(v, t)
-	if !ok {
+	nextV, nextT, path, err := p.path.Match(v, t)
+	if err != nil {
 		return k(false, nil)
 	}
 	nextP := &idPath{


### PR DESCRIPTION
Simplify the return type of (Path).Match by eliminating the redundant `bool` returned from (Path).Match. The `bool` indicated whether the path matched, but this is already communicated as a non-`-nil` `error`.

Make the return values consistent and easier to interpret. If there is a match, the `error` is `nil` and the other fields are populated. If there is no match, `error` is non-`nil` and the other fields are `nil`.