### PR TITLE
reflow/syntax: digest exprexec in stdEvalK

### DIFF
--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1561,9 +1561,20 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 		}
 		e.Left.digest(dw, env2)
 	case ExprExec:
+		fm := e.Type.Tupled().FieldMap()
+		for _, arg := range e.Template.Args {
+			if arg.Kind == ExprIdent && fm[arg.Ident] != nil {
+				continue
+			}
+			if arg.Type.Kind == types.FileKind || arg.Type.Kind == types.DirKind {
+				arg.digest(dw, env)
+			}
+		}
+	case ExprBuiltin:
 		e.digest(dw, env)
+	default:
+		panic(fmt.Sprintf("stdEvalK used for %v", e.Kind))
 	}
-
 }
 
 // makeResources constructs a resource specification

--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1548,6 +1548,8 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 		for _, f := range e.Fields {
 			f.Expr.digest(dw, env)
 		}
+	case ExprCompr:
+		panic("stdEvalK used for ExprCompr")
 	case ExprBlock:
 		env2 := env.Push()
 		i := 0
@@ -1558,6 +1560,7 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 			}
 		}
 		e.Left.digest(dw, env2)
+		
 	case ExprExec:
 		fm := e.Type.Tupled().FieldMap()
 		for _, arg := range e.Template.Args {
@@ -1568,9 +1571,6 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 				arg.digest(dw, env)
 			}
 		}
-	case ExprBuiltin:
-	default:
-		panic(fmt.Sprintf("stdEvalK used for %v", e.Kind))
 	}
 }
 

--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1560,6 +1560,8 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 			}
 		}
 		e.Left.digest(dw, env2)
+	case ExprExec:
+		e.digest(dw, env)
 	}
 
 }

--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1571,7 +1571,6 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 			}
 		}
 	case ExprBuiltin:
-		e.digest(dw, env)
 	default:
 		panic(fmt.Sprintf("stdEvalK used for %v", e.Kind))
 	}

--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1548,8 +1548,6 @@ var stdEvalK evalK = func(e *Expr, env *values.Env, dw io.Writer) {
 		for _, f := range e.Fields {
 			f.Expr.digest(dw, env)
 		}
-	case ExprCompr:
-		panic("stdEvalK used for ExprCompr")
 	case ExprBlock:
 		env2 := env.Push()
 		i := 0


### PR DESCRIPTION
If an exec has delayed dependencies, we need to digest them while computing the flow digest. Without this, execs with delayed dependencies can result in having same logical digests, which is incorrect. 

No tests yet. will add some. Also i feel like we should cover all the cases here that are relevant and panic for cases which are no supposed to use this (like compr).