### PR TITLE
reflow/syntax: fix digest computation for comprehension expressions

### DIFF
--- a/syntax/digest_test.go
+++ b/syntax/digest_test.go
@@ -67,16 +67,22 @@ func TestDigestDelay(t *testing.T) {
 }
 
 func TestDigestCompr(t *testing.T) {
-	for _, expr := range []string{
-		`[x*x | x <- delay([1,2,3])]`,
-		`[y*y | y <- delay([1,2,3])]`,
+	for _, tc := range []struct {
+		expr string
+		want string
+	}{
+		// we expect the first two cases to have the same digest because they are equivalent when evaluated
+		{`[x*x | x <- delay([1,2,3])]`, "sha256:337a09abbd076b3c5744b6fc7eec05f3035a79431503b452153aced03a741d57"},
+		{`[y*y | y <- delay([1,2,3])]`, "sha256:337a09abbd076b3c5744b6fc7eec05f3035a79431503b452153aced03a741d57"},
+		// despite having the same identifiers as the previous case, this digest should be different
+		{`[y*y | y <- delay([4,5,6])]`, "sha256:1a62e182832898d8d2e9d096be2af02302aa186732c5dfdb8f797f4ce9469462"},
 	} {
-		v, _, _, err := eval(expr)
+		v, _, _, err := eval(tc.expr)
 		if err != nil {
-			t.Fatalf("%s: %v", expr, err)
+			t.Fatalf("%s: %v", tc.expr, err)
 		}
 		f := v.(*flow.Flow)
-		if got, want := f.Digest().String(), "sha256:8310ad9a33309b3b9b37c1bed2ec7898757cad3b3b5929aee538797bfee8fba0"; got != want {
+		if got, want := f.Digest().String(), tc.want; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	}

--- a/syntax/eval.go
+++ b/syntax/eval.go
@@ -1265,13 +1265,15 @@ func (e *Expr) evalComprK(sess *Session, env *values.Env, ident string, begin in
 		// TODO: make sure we compute the same digest for the single-clause case.
 		//	(and test this)
 		env2 := env.Push()
-		for i, j := begin, 0; i < len(e.ComprClauses); i++ {
+		for i := begin; i < len(e.ComprClauses); i++ {
 			clause := e.ComprClauses[i]
 			switch clause.Kind {
 			case ComprEnum:
-				for _, id := range clause.Pat.Idents(nil) {
-					env2.Bind(id, digestN(j))
-					j++
+				for _, m := range clause.Pat.Matchers() {
+					if m.Kind != MatchValue || m.Ident == "" {
+						continue
+					}
+					env2.Bind(m.Ident, m.Path().Digest())
 				}
 			case ComprFilter:
 			}

--- a/syntax/eval_test/eval_test.go
+++ b/syntax/eval_test/eval_test.go
@@ -33,6 +33,7 @@ func TestEval(t *testing.T) {
 		"testdata/reduce.rf",
 		"testdata/fold.rf",
 		"testdata/test_flag_dependence.rf",
+		"testdata/compr.rf",
 	}
 	testutil.RunReflowTests(t, tests)
 }

--- a/syntax/eval_test/testdata/compr.rf
+++ b/syntax/eval_test/testdata/compr.rf
@@ -1,0 +1,70 @@
+val d = dir("testdata/testdir")
+val filelist = list(d)
+val filemap = map(d)
+
+// List comprehension test cases
+
+val TestListComprTuple = {
+	 val (paths, files) = ([p | (p, x) <- filelist], [f | (y, f) <- filelist])
+	 ((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestListComprTupleFirstIsBlank = {
+	 val (paths, files) = ([p | (p, _) <- filelist], [f | (y, f) <- filelist])
+	 ((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestListComprTupleSecondIsBlank = {
+	 val (paths, files) = ([p | (p, x) <- filelist], [f | (_, f) <- filelist])
+	 ((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestListComprTupleTwoIgnorePatterns = {
+	val (paths, files) = ([p | (p, _) <- filelist], [f | (_, f) <- filelist])
+	((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestListComprTupleSameVar = {
+	val (paths, files) = ([x | (x, _) <- filelist], [x | (_, x) <- filelist])
+	((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestListComprNestedTupleBothBlankIdentifiers = {
+	val stuff = [((p, f), (p, f)) | (p, f) <- filelist]
+	val (paths, files) = ([p | ((_, _), (p, _)) <- stuff], [f | (_, (_, f)) <- stuff])
+	((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+val TestMultipleListsComprTupleSameVar = {
+	val intlist = [1]
+	val (pathLenPlusOne, fileSizePlusOne) = (
+		[len(x) + y | (x, _) <- filelist, y <- intlist], // len(x) is the length of the path str
+		[len(x) + y | (_, x) <- filelist, y <- intlist]) // len(x) is the size of the file
+	((pathLenPlusOne[0] == len("0") + 1) && (fileSizePlusOne[0] == len(file("testdata/testdir/0")) + 1))
+}
+
+val TestFilterListComprTupleSameVar = {
+	val (paths, files) = ([x | (x, _) <- filelist, if len(x) >= 0], [x | (_, x) <- filelist, if len(x) >= 0])
+	((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+type PathFile #Path(string) | #File(file)
+val TestListComprVariant = {
+	val ps = [#Path("0")]
+	val fs = [#File(file("testdata/testdir/0"))]
+	val (paths, files) = ([p | #Path(p) <- delay(ps)], [f | #File(f) <- delay(fs)])
+	((paths[0] == "0") && (files[0] == file("testdata/testdir/0")))
+}
+
+// Map comprehension test cases: all the files in testdir are empty, so we can always
+// expect files[0] to have a size of 0 bytes (regardless of the map iteration order).
+
+val TestMapComprTupleTwoIgnorePatterns = {
+	val (paths, files) = ([p | (p, _) <- filemap], [f | (_, f) <- filemap])
+	((len(paths) == 20) && (len(files[0]) == 0))
+}
+
+val TestMapComprTupleSameVar = {
+	val (paths, files) = ([x | (x, _) <- filemap], [x | (_, x) <- filemap])
+	((len(paths) == 20) && (len(files[0]) == 0))
+}

--- a/values/env.go
+++ b/values/env.go
@@ -6,6 +6,7 @@ package values
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/grailbio/base/digest"
 	"github.com/grailbio/reflow/types"
@@ -13,6 +14,16 @@ import (
 
 // Symtab is a symbol table of values.
 type Symtab map[string]T
+
+func (s Symtab) PrettyString() string {
+	b := strings.Builder{}
+	b.WriteString("--------------Symtab--------------\n")
+	for k, v := range s {
+		b.WriteString(fmt.Sprintf("%s = %v\n", k, v))
+	}
+	b.WriteString("----------------------------------\n")
+	return b.String()
+}
 
 // Env binds identifiers to evaluation.
 type Env struct {


### PR DESCRIPTION
**Bug Description**

Suppose we have two local files, `foo/bar/file1` and `foo/file2` in 
`testdata/testdir` and the following reflow code:
```
val d = dir("testdata/testdir")
val filelist = list(d)
```

Filelist is a list of two-element tuples; the first element of each
tuple is a string path and the second is a file object. If we wanted to
unzip filelist into two separate lists, one with the paths and one
with the files, we could use a list comprehension like this:
```
val (paths, files) = ([p | (p, x) <- filelist], [f | (y, f) <- filelist])
```

As expected, the result when evaluated by reflow is:
```
paths = ["foo/bar/file1", "foo/file2"]
files = [file("foo/bar/file1")), file("foo/file2"))]
```

The above code is correct, but we didn’t actually use the pattern
matched x and y variables. We could instead use the ignore pattern to
achieve the same result like this:
```
val (paths, files) = ([p | (p, _) <- filelist], [f | (_, f) <- filelist])
```

In this version, we would expect the same values for path and files.
However, due to a bug we actually get:
```
paths = ["foo/bar/file1", "foo/file2"]
files = ["foo/bar/file1", "foo/file2"]
```

The values of files is incorrect; it should not be the same as paths.

**Root Cause & Fix**

The root cause of this bug is that two different expressions,
`[p | (p, _) <- filelist]` and `[f | (_, f) <- filelist]`, are resolved
to the same digest; thus the value computed for the expression that is
evaluated first is reused for the expression evaluated second. 
Note that the list being processed must be a delayed flow in order
for this bug to occur.

This diff fixes the bug by modifying the environment that is used to
compute the digest for comprehensions.

Before the fix, each identifier in the comprehension's pattern
was bound to `digestN(j)` where `j` is the index of the identifier in
the pattern. Since the ignore pattern `_` is ignored, it is not included
in the identifiers. As a result, both `(p, _)` and `(_, f)` will bind to
`digestN(0)` because there is only 1 non-empty identifier.

With this fix, we no longer bind identifiers to the environment using
`digestN(j)`. Instead, we bind them to a digest of their matcher's path.
This path is based on the actual value being pattern matched and is
unaffected by the use of ignore patterns. A visual example of the fix:
```
// before
(p, _) -> digestN(0)
(_, f) -> digestN(0)

// after
(p, _) -> digest([tuple(0) value])
(_, f) -> digest([tuple(1) value])
```